### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ DummyController = Ember.Controller.extend()
 `export default DummyController`
 ```
 
-Replace ember-cli-coffeescript with ember-cli-coffees6 and you can use a much more natural syntax:
+Enhance ember-cli-coffeescript with ember-cli-coffees6 and you can use a much more natural syntax:
 
 ```coffee
 import Ember from 'ember'


### PR DESCRIPTION
'replace' makes it sound like i should remove e-c-coffeescript, but further down it's made clear that i still need it installed.
